### PR TITLE
fix "path/to/component" as component name

### DIFF
--- a/src/component/index.ts
+++ b/src/component/index.ts
@@ -1,45 +1,61 @@
 import { strings } from '@angular-devkit/core';
 import {
-    apply,
-    applyTemplates,
-    chain,
-    externalSchematic,
-    mergeWith,
-    move,
-    Rule, Tree,
-    url
+  apply,
+  applyTemplates,
+  chain,
+  externalSchematic,
+  mergeWith,
+  move,
+  Rule,
+  Tree,
+  url,
 } from '@angular-devkit/schematics';
 import { Style } from '@schematics/angular/component/schema';
 import { parseName } from '@schematics/angular/utility/parse-name';
-import { buildDefaultPath, getProject } from '@schematics/angular/utility/project';
+import {
+  buildDefaultPath,
+  getProject,
+} from '@schematics/angular/utility/project';
 
 const configKey = '@schematics/angular:component';
 
 export function component(_options: any): Rule {
-    return chain([
-        (host: Tree) => {
-            const project = getProject(host, _options.project);
-            const style = project.schematics && project.schematics[configKey] && project.schematics[configKey].style;
-            _options.style = style || Style.Css;
-        },
-        externalSchematic('@schematics/angular', 'module', {name: _options.name}),
-        externalSchematic('@schematics/angular', 'component', {
-            name: _options.name,
-            module: _options.name,
-            get style() { return _options.style }
-        }),
-        (host: Tree) => {
-            const project = getProject(host, _options.project);
-            const parsedPath = parseName(buildDefaultPath(project), _options.name);
-            const templateSource = apply(url('./files'), [
-                applyTemplates({
-                    ...strings,
-                    ..._options,
-                }),
-                move(parsedPath.path),
-            ]);
+  return chain([
+    (host: Tree) => {
+      const project = getProject(host, _options.project);
+      const style =
+        project.schematics &&
+        project.schematics[configKey] &&
+        project.schematics[configKey].style;
+      _options.style = style || Style.Css;
+    },
+    externalSchematic('@schematics/angular', 'module', { name: _options.name }),
+    externalSchematic('@schematics/angular', 'component', {
+      name: _options.name,
+      module: _options.name,
+      get style() {
+        return _options.style;
+      },
+    }),
+    (host: Tree) => {
+      const project = getProject(host, _options.project);
+      const parsedPath = parseName(buildDefaultPath(project), _options.name);
 
-            return mergeWith(templateSource);
-        }
-    ]);
+      /* Gets the name of a path. Example: path/to/somewhere/component sets _option.name to component
+         As a result the story is not saved in src/app/path/to/somewhere/path/to/somewhere/component/path/to/somewhere/component.stories.ts
+         but in src/app/path/to/somewhere/component/component.stories.ts
+     */
+      _options.name = _options.name.split('/').slice(-1).join();
+
+      const templateSource = apply(url('./files'), [
+        applyTemplates({
+          ...strings,
+          ..._options,
+        }),
+        move(parsedPath.path),
+      ]);
+
+      return mergeWith(templateSource);
+    },
+  ]);
 }


### PR DESCRIPTION
 `ng generate @ngx-storybook/schematics:c path/to/somewhere/component
`

creates a story in 

> src/app/path/to/somewhere/path/to/somewhere/component/path/to/somewhere/component.stories.ts

but the component and the module to the story are in 

> src/app/path/to/somewhere

Modifying `_option.name` before applying it to the template file would fix it.