### PR TITLE
fix #7 respect the current working directory and add path parameter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngx-storybook/schematics",
-  "version": "1.0.0",
+  "version": "1.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/component/index.ts
+++ b/src/component/index.ts
@@ -39,7 +39,11 @@ export function component(_options: any): Rule {
     }),
     (host: Tree) => {
       const project = getProject(host, _options.project);
-      const parsedPath = parseName(buildDefaultPath(project), _options.name);
+
+      if (_options.path === undefined) {
+        _options.path = buildDefaultPath(project);
+      }
+      const parsedPath = parseName(_options.path, _options.name);
 
       /* Gets the name of a path. Example: path/to/somewhere/component sets _option.name to component
          As a result the story is not saved in src/app/path/to/somewhere/path/to/somewhere/component/path/to/somewhere/component.stories.ts

--- a/src/component/schema.json
+++ b/src/component/schema.json
@@ -22,6 +22,15 @@
         "index": 0
       },
       "x-prompt": "What name would you like to use for the module and component?"
+    },
+    "path": {
+      "type": "string",
+      "format": "path",
+      "$default": {
+        "$source": "workingDirectory"
+      },
+      "description": "The path at which to create the component file, relative to the current workspace. Default is a folder with the same name as the component in the project root.",
+      "visible": false
     }
   },
   "required": ["name"]

--- a/src/stories/index.ts
+++ b/src/stories/index.ts
@@ -13,7 +13,10 @@ import { buildDefaultPath, getProject } from '@schematics/angular/utility/projec
 export function stories(_options: any): Rule {
   return (host: Tree) => {
       const project = getProject(host, _options.project);
-      const parsedPath = parseName(buildDefaultPath(project), _options.name);
+    if (_options.path === undefined) {
+      _options.path = buildDefaultPath(project);
+    }
+    const parsedPath = parseName(_options.path, _options.name);
       const templateSource = apply(url('./files'), [
         applyTemplates({
           ...strings,

--- a/src/stories/schema.json
+++ b/src/stories/schema.json
@@ -20,6 +20,15 @@
         "index": 0
       },
       "x-prompt": "What name would you like to use for the stories?"
+    },
+    "path": {
+      "type": "string",
+      "format": "path",
+      "$default": {
+        "$source": "workingDirectory"
+      },
+      "description": "The path at which to create the component file, relative to the current workspace. Default is a folder with the same name as the component in the project root.",
+      "visible": false
     }
   },
   "required": ["name"]


### PR DESCRIPTION
This introduces a `path` parameter to the schematics which defaults to the current working directory. This is the same behavior which the angular schematics implement